### PR TITLE
Repeatable `@Authorization`

### DIFF
--- a/src/main/java/com/webrest/common/annotation/Authorization.java
+++ b/src/main/java/com/webrest/common/annotation/Authorization.java
@@ -1,6 +1,7 @@
 package com.webrest.common.annotation;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -11,6 +12,7 @@ import org.springframework.http.HttpMethod;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
+@Repeatable(Authorizations.class)
 public @interface Authorization {
 	AuthorizedFeature feature() default AuthorizedFeature.NONE;
 	AuthorizedAction action() default AuthorizedAction.NONE;

--- a/src/main/java/com/webrest/common/annotation/Authorizations.java
+++ b/src/main/java/com/webrest/common/annotation/Authorizations.java
@@ -1,0 +1,12 @@
+package com.webrest.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface Authorizations {
+	Authorization[] value() default {};
+}


### PR DESCRIPTION
### What i have done

- `Repeatable` feature added in `Authorization` annotation.
- `AuthorizationService` updated accordingly.

#### Background

Apart from the web routes, rest endpoints are different. Same url can serve different purpose based on the the difference in the http verb used.

In example:

```
GET /cars/{carId} // used for getting a single car details
PUT /cars/{carId} // used for updating a single car
DELETE /cars/{carId} // used for deleting a single car
```

So the route `/cars/{carId}` should handle all these possibilities. To support these, `@Authorization` annotation is now made repeatable.