### PR TITLE
Dockerfile upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,41 @@
-# TODO: Shift to eclipse termurin openjdk are no longer maintaining their builds.
-# See deprecation notice here : https://hub.docker.com/_/openjdk
-FROM openjdk:11.0.13-jre-slim
+####################
+# Stage: 1 `builder`
+####################
+FROM azul/zulu-openjdk-alpine:17.0.9 AS builder
 
-COPY target/*.jar app.jar
+RUN apk add maven binutils
 
-## Default remote-debug on
-CMD ["java", "-jar", "/app.jar"]
+WORKDIR /app
+COPY pom.xml .
+RUN mvn dependency:resolve
+COPY src ./src/
+RUN mvn clean package
+
+RUN mv ./target/*.jar ./target/app.jar
+WORKDIR /app/target
+RUN jar xf app.jar
+RUN jdeps --class-path './BOOT-INF/lib/*' -q \
+	--recursive \
+	--multi-release 17 \
+	--ignore-missing-deps \
+	--print-module-deps \
+	app.jar > jdeps.info
+
+RUN jlink --add-modules $(cat jdeps.info) \
+	--strip-debug \
+	--compress 2 \
+	--no-header-files \
+	--no-man-pages \
+	--output /custom-jre
+
+####################
+# Stage: 2 `runner`
+####################
+FROM alpine:3.18.4 AS runner
+ENV JAVA_HOME /user/java/custom-jre
+ENV PATH $JAVA_HOME/bin:$PATH
+COPY --from=builder /custom-jre $JAVA_HOME
+WORKDIR /app
+COPY --from=builder /app/target/app.jar .
+EXPOSE 8000
+ENTRYPOINT java -jar app.jar

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
         reservations:
           memory: 300M
     environment:
-    - DB_SERVER=${WEB_REST_DB_SERVER:-jdbc:mysql://db:3306/webrest}
+    - DB_SERVER=${WEB_REST_DB_SERVER:-jdbc:mysql://db:3306/webrest?useSSL=false}
     - DB_USERNAME=${WEB_REST_DB_USERNAME:-webrest-user}
     - DB_PASSWORD=${WEB_REST_DB_PASSWORD:-secret}
     - DB_DRIVER=${WEB_REST_DB_DRIVER:-com.mysql.cj.jdbc.Driver}
@@ -42,6 +42,7 @@ services:
     - REDIS_PORT=${REDIS_PORT:-6379}
     - REDIS_PASSWORD=${REDIS_PASSWORD:-secret}
     - SPRING_FLYWAY_ENABLED=true
+    - SPRING_FLYWAY_BASELINE_ON_MIGRATE=true
     depends_on:
       db:
         condition: service_healthy

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 	<description>Simple starter for building web and rest application.</description>
 
 	<properties>
-		<java.version>11</java.version>
+		<java.version>17</java.version>
 		<version.hibernate-jpamodelgen>5.3.7.Final</version.hibernate-jpamodelgen>
 	</properties>
 	<dependencies>

--- a/redis/Dockerfile
+++ b/redis/Dockerfile
@@ -1,3 +1,3 @@
-FROM redis:6.2.7
+FROM redis:6.2.14-alpine3.18
 COPY redis.conf /usr/local/etc/redis/redis.conf
 CMD [ "redis-server", "/usr/local/etc/redis/redis.conf" ]

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -75,6 +75,7 @@ ROLE_ACCESS_HASH_KEY=role-access
 # Flyway
 ###
 spring.flyway.enabled=${SPRING_FLYWAY_ENABLED:false}
+spring.flyway.baseline-on-migrate=${SPRING_FLYWAY_BASELINE_ON_MIGRATE:false}
 
 ###
 # App Specific


### PR DESCRIPTION
### What i have done | Issue #42 

- `dockerfile` multi staged, `jdeps` and `jlink` configured for smaller image footprint.
- lighter alpine image used for redis.
- java version updated from 11 to 17.
- after using jlink, mysql connector requires `useSSL=false` specified in the db path.
- `baseline-on-migrate` required for first time migration.